### PR TITLE
changed include of arduino.h to Arduino.h

### DIFF
--- a/src/LedRGB.cpp
+++ b/src/LedRGB.cpp
@@ -5,7 +5,7 @@ Modified 22-06-2019
 Version 1.0.0
 */
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <LedRGB.h>
 
 LedRGB::LedRGB(int pinR, int pinG, int pinB, int mode)

--- a/src/LedRGB.h
+++ b/src/LedRGB.h
@@ -6,7 +6,7 @@ Version 1.0.0
 */
 #ifndef LedRGB_h
 #define LedRGB_h
-#include <arduino.h>
+#include <Arduino.h>
 
 #define CA 0
 #define CC 1


### PR DESCRIPTION
#include <arduino.h> wasn't found on manjaro linux with arduino ide downloaded from arduino.cc and also installed over yay.
I think it is a case sensitive problem. I changed the include to <Arduino.h> and it works fine.